### PR TITLE
Revert "init: remove session keyring workaround for old kernels"

### DIFF
--- a/init/Android.bp
+++ b/init/Android.bp
@@ -195,6 +195,7 @@ libinit_cc_defaults {
         "libfs_mgr",
         "libgsi",
         "libhidl-gen-utils",
+        "libkeyutils",
         "liblog",
         "liblogwrap",
         "liblp",

--- a/init/builtins.cpp
+++ b/init/builtins.cpp
@@ -592,6 +592,9 @@ static Result<void> queue_fs_event(int code) {
     } else if (code == FS_MGR_MNTALL_DEV_FILE_ENCRYPTED ||
                code == FS_MGR_MNTALL_DEV_IS_METADATA_ENCRYPTED ||
                code == FS_MGR_MNTALL_DEV_NEEDS_METADATA_ENCRYPTION) {
+        if (!FscryptInstallKeyring()) {
+            return Error() << "FscryptInstallKeyring() failed";
+        }
         SetProperty("ro.crypto.state", "encrypted");
 
         // Although encrypted, vold has already set the device up, so we do not need to

--- a/init/fscrypt_init_extensions.cpp
+++ b/init/fscrypt_init_extensions.cpp
@@ -34,11 +34,27 @@
 #include <cutils/properties.h>
 #include <cutils/sockets.h>
 #include <fscrypt/fscrypt.h>
+#include <keyutils.h>
 #include <logwrap/logwrap.h>
 
 #define TAG "fscrypt"
 
 using namespace android::fscrypt;
+
+bool FscryptInstallKeyring() {
+    if (keyctl_search(KEY_SPEC_SESSION_KEYRING, "keyring", "fscrypt", 0) != -1) {
+        LOG(INFO) << "Keyring is already created";
+        return true;
+    }
+    key_serial_t device_keyring = add_key("keyring", "fscrypt", 0, 0, KEY_SPEC_SESSION_KEYRING);
+
+    if (device_keyring == -1) {
+        PLOG(ERROR) << "Failed to create keyring";
+        return false;
+    }
+    LOG(INFO) << "Keyring created with id " << device_keyring << " in process " << getpid();
+    return true;
+}
 
 // TODO(b/139378601): use a single central implementation of this.
 static void delete_dir_contents(const std::string& dir) {

--- a/init/fscrypt_init_extensions.h
+++ b/init/fscrypt_init_extensions.h
@@ -25,5 +25,6 @@ enum class FscryptAction {
     kDeleteIfNecessary,
 };
 
+bool FscryptInstallKeyring();
 bool FscryptSetDirectoryPolicy(const std::string& ref_basename, FscryptAction action,
                                const std::string& dir);

--- a/init/fuzzer/Android.bp
+++ b/init/fuzzer/Android.bp
@@ -32,6 +32,7 @@ cc_defaults {
         "libbase",
         "libfs_mgr",
         "libhidl-gen-utils",
+        "libkeyutils",
         "liblog",
         "libprocessgroup",
         "libselinux",

--- a/init/init.cpp
+++ b/init/init.cpp
@@ -54,6 +54,7 @@
 #include <android-base/thread_annotations.h>
 #include <fs_avb/fs_avb.h>
 #include <fs_mgr_vendor_overlay.h>
+#include <keyutils.h>
 #include <libavb/libavb.h>
 #include <libgsi/libgsi.h>
 #include <libsnapshot/snapshot.h>
@@ -969,6 +970,11 @@ int SecondStageMain(int argc, char** argv) {
         LOG(ERROR) << "Unable to write " << DEFAULT_OOM_SCORE_ADJUST
                    << " to /proc/1/oom_score_adj: " << result.error();
     }
+
+    // Set up a session keyring that all processes will have access to. It
+    // will hold things like FBE encryption keys. No process should override
+    // its session keyring.
+    keyctl_get_keyring_ID(KEY_SPEC_SESSION_KEYRING, 1);
 
     // Indicate that booting is in progress to background fw loaders, etc.
     close(open("/dev/.booting", O_WRONLY | O_CREAT | O_CLOEXEC, 0000));


### PR DESCRIPTION
Reason for revert: Still needed for <4.14 devices.

This reverts commit 5d7c35ce205f1b4afadd6a1725c0b5e03962a97c.

Change-Id: I695f04514f4334c77636120d94990b0b6eaa11a3